### PR TITLE
Add usage documentation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,177 @@
+# Using TestFX and Monocle with Unit Tests
+[TestFX](https://github.com/TestFX/TestFX) is a UI test framework for JavaFX.
+To use TestFX it simply needs to be included as a test dependency on the 
+project.
+
+## Using TestFX 4 with Maven on Java 9 and Later
+Using TestFX 4 on Java 9 takes a bit of work because it is normally configured
+to run against Java 8. However, with two configuration changes made to the 
+build configuration TestFX will work.
+
+### TestFX 4 Dependency Configuration
+The TestFX dependency configuration needs to exclude the testfx-internal-java8
+dependency and in turn include the testfx-internal-java9 dependency. Here is 
+the Maven configuration:
+
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>testfx-core</artifactId>
+	  <version>${testfx.version}</version>
+	  <scope>test</scope>
+	  <exclusions>
+	    <exclusion>
+	      <groupId>org.testfx</groupId>
+	      <artifactId>testfx-internal-java8</artifactId>
+	    </exclusion>
+	  </exclusions>
+	</dependency>
+	
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>testfx-internal-java9</artifactId>
+	  <version>${testfx.version}</version>
+	  <scope>test</scope>
+	</dependency>
+
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>testfx-junit</artifactId>
+	  <version>${testfx.version}</version>
+	  <scope>test</scope>
+	</dependency>
+
+### JVM Runtime Configuration
+Because TestFX still needs to use protected reflection calls, the JVM needs to
+be configured to allow these calls. The following parameters needs to be added
+to the JVM command line:
+
+	--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED
+
+This can be configured for the Maven Surefire plugin:
+
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-surefire-plugin</artifactId>
+	  <configuration>
+	    <argLine>--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED</argLine>
+	  </configuration>
+	</plugin>
+
+## Using TestFX 4 with Maven on Java 8
+Using TestFX 4 on Java 8 only requires adding the dependencies to the test
+configuration:
+
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>testfx-core</artifactId>
+	  <version>${testfx.version}</version>
+	  <scope>test</scope>
+	</dependency>
+	
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>testfx-junit</artifactId>
+	  <version>${testfx.version}</version>
+	  <scope>test</scope>
+	</dependency>
+
+# Using Monocle with TestFX
+Using Monocle with TestFX during unit testing will allow the tests to be run in 
+headless mode. This allows for faster and more accurate tests during 
+development because tests can be run without taking over the developer mouse 
+and keyboard and provides a consistent UI environment across platforms, 
+avoiding problems like HiDPI rounding errors and different window size 
+measurements. [Prebuilt Monocle libraries](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.testfx%22%20AND%20a%3A%22openjfx-monocle%22) 
+can be found on [Maven Central](http://search.maven.org).
+
+## Installing Monocle on Java 9 and Later
+Monocle can simply be included on the classpath using Java 9.
+
+## Installing Monocle on Java 8
+Monocle must be installed as an extension library on Java 8. Copy the Monocle
+jar to:
+
+	<JDK_HOME>/jre/lib/ext
+
+## Maven Configuration
+### Maven Configuration on Java 9
+
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>openjfx-monocle</artifactId>
+	  <version>jdk-9+181</version>
+	  <scope>test</scope>
+	</dependency>
+
+### Maven Configuration on Java 8
+
+	<dependency>
+	  <groupId>org.testfx</groupId>
+	  <artifactId>openjfx-monocle</artifactId>
+	  <version>8u76-b04</version>
+	  <scope>test</scope>
+	</dependency>
+
+## Using Monocle
+### Using Monocle on Java 9 and Later
+When running tests with Java 9 and later the following system properties need 
+to be added at runtime:
+
+	-Dprism.order=sw
+	-Dprism.text=t2k
+	-Dtestfx.robot=glass
+	-Dtestfx.headless=true
+	-Dtestfx.setup.timeout=2500
+
+These can be added when launching the JVM:
+
+	mvn -Dprism.order=sw -Dprism.text=t2k -Dtestfx.robot=glass -Dtestfx.headless=true -Dtestfx.setup.timeout=2500 clean package
+
+or as part of the Maven Surefire configuration:
+
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-surefire-plugin</artifactId>
+	  <configuration>
+	    <argLine>--add-opens=java.base/java.util=ALL-UNNAMED --add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED -Dprism.order=sw -Dprism.text=t2k -Dtestfx.robot=glass -Dtestfx.headless=true -Dtestfx.setup.timeout=2500</argLine>
+	    <systemPropertyVariables>
+	      <prism.order>sw</prism.order>
+	      <prism.text>t2k</prism.text>
+	      <testfx.robot>glass</testfx.robot>
+	      <testfx.headless>true</testfx.headless>
+	      <testfx.setup.timeout>2500</testfx.setup.timeout>
+	    </systemPropertyVariables>
+	  </configuration>
+	</plugin>
+	
+### Using Monocle on Java 8
+When running tests with Java 8 the following system properties need to be added 
+at runtime:
+
+	-Dglass.platform=Monocle 
+	-Dmonocle.platform=Headless 
+	-Dprism.order=sw 
+	-Dprism.text=t2k 
+	-Dtestfx.robot=glass
+
+These can be added when launching the JVM:
+
+	mvn -Dglass.platform=Monocle -Dmonocle.platform=Headless -Dprism.order=sw -Dprism.text=t2k -Dtestfx.robot=glass clean package
+
+or as part of the Maven Surefire configuration:
+
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-surefire-plugin</artifactId>
+	  <configuration>
+	    <systemPropertyVariables>
+	      <monocle.platform>Headless</monocle.platform>
+	      <prism.order>sw</prism.order>
+	      <prism.text>t2k</prism.text>
+	      <testfx.robot>glass</testfx.robot>
+	      <testfx.headless>true</testfx.headless>
+	      <testfx.setup.timeout>2500</testfx.setup.timeout>
+	    </systemPropertyVariables>
+	  </configuration>
+	</plugin>
+


### PR DESCRIPTION
Usage documentation for Monocle on TestFX is very hard to find. We have put together this documentation to aid in the use of Monocle with TestFX.